### PR TITLE
[InfoBarResolutionSelection] Fix videoMode suffix

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -4321,8 +4321,8 @@ class InfoBarResolutionSelection:
 			video = videoMode
 			if videoMode.endswith("23"):
 				video = "%s.976" % videoMode
-			if videoMode[-1].isdigit():
-				video = "%sHz" % videoMode
+			if videoMode[-1].isdigit() and "x" not in videoMode or "_" in videoMode:
+				video = "%sHz" % videoMode.replace("_", " ")
 			resList.append((video, videoMode))
 		videoMode = avControl.getVideoMode("Unknown")
 		keys = ["green", "yellow", "blue", "", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]


### PR DESCRIPTION
rates["PC"][x][-1].isdigit() but have no rate!
For example "640x480" was "640x480Hz"